### PR TITLE
Fix. maths operators do not clone correctly

### DIFF
--- a/src/main/resources/com/ardublock/block/ardublock.xml
+++ b/src/main/resources/com/ardublock/block/ardublock.xml
@@ -287,7 +287,10 @@
 				</text>
 			</description>
 			<BlockConnectors>
-				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" />
+				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 			</BlockConnectors>
@@ -304,7 +307,10 @@
 				</text>
 			</description>
 			<BlockConnectors>
-				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" />
+				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 			</BlockConnectors>
@@ -321,7 +327,10 @@
 				</text>
 			</description>
 			<BlockConnectors>
-				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" />
+				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 			</BlockConnectors>
@@ -338,7 +347,10 @@
 				</text>
 			</description>
 			<BlockConnectors>
-				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" />
+				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 			</BlockConnectors>
@@ -346,7 +358,10 @@
 
 		<BlockGenus name="modulo" kind="function" color="149 193 31" initlabel="bg.modulo">
 			<BlockConnectors>
-				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" />
+				<BlockConnector label="" connector-kind="plug" connector-type="number" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 				<BlockConnector label="" connector-kind="socket" connector-type="number" position-type="bottom" />
 			</BlockConnectors>
@@ -424,7 +439,10 @@
 		
 		<BlockGenus name="min" kind="function" color="149 193 31" initlabel="bg.min">
 			<BlockConnectors>
-				<BlockConnector connector-type="number" connector-kind="plug" position-type="mirror" />
+				<BlockConnector connector-type="number" connector-kind="plug" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector connector-type="number" connector-kind="socket" position-type="bottom" />
 				<BlockConnector connector-type="number" connector-kind="socket" position-type="bottom" />
 			</BlockConnectors>
@@ -432,7 +450,10 @@
 
 		<BlockGenus name="max" kind="function" color="149 193 31" initlabel="bg.max">
 			<BlockConnectors>
-				<BlockConnector connector-type="number" connector-kind="plug" position-type="mirror" />
+				<BlockConnector connector-type="number" connector-kind="plug" position-type="mirror" >
+					<!-- CLUDGE:: This apparently daft line enables 'clone' to work correctly on this BlockGenus -->
+					<DefaultArg genus-name="dummy" label="" />
+				</BlockConnector>
 				<BlockConnector connector-type="number" connector-kind="socket" position-type="bottom" />
 				<BlockConnector connector-type="number" connector-kind="socket" position-type="bottom" />
 			</BlockConnectors>


### PR DESCRIPTION
Just a quick fix.
There must be a better way to do this?
