### PR TITLE
Fix. #60. user commands in 'setup' are pruned and forced unique

### DIFF
--- a/src/main/java/com/ardublock/translator/Translator.java
+++ b/src/main/java/com/ardublock/translator/Translator.java
@@ -155,6 +155,11 @@ public class Translator
 		}
 	}
 	
+	public void addSetupCommandForced(String command)
+	{
+		setupCommand.add(command);
+	}
+	
 	public void addDefinitionCommand(String command)
 	{
 		definitionSet.add(command);

--- a/src/main/java/com/ardublock/translator/block/CodeSetupBlock.java
+++ b/src/main/java/com/ardublock/translator/block/CodeSetupBlock.java
@@ -16,11 +16,11 @@ public class CodeSetupBlock extends TranslatorBlock
 	{
 		
 		TranslatorBlock translatorBlock = this.getRequiredTranslatorBlockAtSocket(0);
-		String ret ="\t"+ translatorBlock.toCode();
+		String ret = translatorBlock.toCode();
 		//ret=ret.substring(1);
 		//ret=ret.replace(ret.substring(ret.length()-1),"");
 		ret=ret+"\n";
-		translator.addSetupCommand(ret);
+		translator.addSetupCommandForced(ret);
 		return "";
 	}
 }

--- a/src/main/java/com/ardublock/translator/block/ProgramBlock.java
+++ b/src/main/java/com/ardublock/translator/block/ProgramBlock.java
@@ -50,7 +50,7 @@ public class ProgramBlock extends TranslatorBlock
 	{
 		for (String command : setupCommand)
 		{
-			translator.addSetupCommand(command);
+			translator.addSetupCommandForced(command);
 		}
 	}
 	


### PR DESCRIPTION
**Sorry**. I know heqichen said he would fix this and will probably do a better job, but I needed this quickly.

**Changes…**
Tiny new function to Translator `addSetupCommandForced` which **does** add duplicate commands – not like `addSetupCommand`

**_Big Change**_:: ProgramBlock now uses `addSetupCommandForced` to create setup section

CodeSetupBlock now uses `addSetupCommandForced`

SetupBlock is unchanged as it is not used?

**_Basic testing seems OK but problems might be…**_

Some existing Blocks might need to think if to use `addSetupCommandForced` or `addSetupCommand` and what will happen if they are in the setup section more than once.

Some existing .abp programs might break if they expect duplicate setup commands to be auto-removed?
