### PR TITLE
It is better to make the object String thet then to apply an equals m…

### DIFF
--- a/src/main/java/com/ardublock/translator/block/IrGetCodeBlock.java
+++ b/src/main/java/com/ardublock/translator/block/IrGetCodeBlock.java
@@ -23,27 +23,18 @@ public class IrGetCodeBlock extends TranslatorBlock
 			"  __ab_irrecv.enableIRIn();\n" + 
 			"  __ab_irrecv.resume();\n" + 
 			"}\n" +
-			"void charsToUpper(char *str)\n" + 
-			"{\n" + 
-			"  int p=0;\n" + 
-			"  while(str[p] != 0)\n" + 
-			"  {\n" + 
-			"    str[p] = toupper(str[p]);\n" + 
-			"    ++p;\n" + 
-			"  }\n" + 
-			"}\n" + 
-			"void __ab_getIrCommand(char *receivedCommand)\n" + 
+			"void __ab_getIrCommand(String &receivedCommand)\n" + 
 			"{\n" + 
 			"  decode_results result;\n" + 
 			"  if (__ab_irrecv.decode(&result))\n" + 
 			"  {\n" + 
-			"    ltoa(result.value, receivedCommand, 16);\n" + 
-			"    charsToUpper(receivedCommand);\n" + 
+                        "    receivedCommand = String(result.value, HEX);\n" + 
+			"    receivedCommand.toUpperCase();\n" + 
 			"    __ab_irrecv.resume();\n" + 
 			"  }\n" + 
 			"  else\n" + 
 			"  {\n" + 
-			"    receivedCommand[0] = '\\0';\n" + 
+			"    receivedCommand = \"\";\n" + 
 			"  }\n" + 
 			"}";
 	

--- a/src/main/java/com/ardublock/translator/block/StringEmptyBlock.java
+++ b/src/main/java/com/ardublock/translator/block/StringEmptyBlock.java
@@ -15,10 +15,10 @@ public class StringEmptyBlock extends TranslatorBlock
 	public String toCode() throws SocketNullException, SubroutineNotDeclaredException
 	{
 		StringBuilder ret = new StringBuilder();
-		ret.append("strlen(");
+		ret.append("");
 		TranslatorBlock tb = this.getRequiredTranslatorBlockAtSocket(0);
 		ret.append(tb.toCode());
-		ret.append(") == 0");
+		ret.append(".length() == 0");
 		return codePrefix + ret + codeSuffix;
 	}
 }


### PR DESCRIPTION
…ethod

The IrGetCode block uses char as the result, but the string validation methods use either char [] or String. This leads to a type mismatch error in the Arduino source code. It is better to replace the return type in IrGetCode with String.